### PR TITLE
#1640: Added mirror support for sense field in menu bar

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -303,7 +303,7 @@ $(document).ready(function() {
      // Empty menu_bar_search_mirror
      $("#adminsearch :input").change(function() {
         $("#menu_bar_search_mirror").val("");
-        $("#menu_bar_translatioh_mirror").val("");
+        $("#menu_bar_translation_mirror").val("");
      });
 
     if (view_type == 'lemma_groups') {


### PR DESCRIPTION
this was never implemented

This pull request makes sure the user input in the Senses search field is incorporated into the query parameters so that it is passed around and is available to the CSV export.
Because the menu bar search fields live in the menu bar, they are copied to the main area of the template so they show up in the form. This was only done for the "Search" field, not the "Senses" field.