### PR TITLE
Use model names for signlanguage and dialect in forms

### DIFF
--- a/media/js/gloss_search.js
+++ b/media/js/gloss_search.js
@@ -70,7 +70,7 @@ function set_signlanguages_dialects() {
         this_selection_choices = $('#signlanguage_selection');
 
         for(i = 0; i < signlanguages.length; i++) {
-            $('#id_signLanguage option').each(function(){
+            $('#id_signlanguage option').each(function(){
                 if ($(this).html() == signlanguages[i]) {
                     optionValues.push($(this).html());
                 };
@@ -78,13 +78,13 @@ function set_signlanguages_dialects() {
         };
     }
 
-    $('#id_dialects').val(null).trigger('change');
+    $('#id_dialect').val(null).trigger('change');
 
     this_selection_dialect_elt = $('#dialect_selection');
-    $('#id_dialects option').each(function(){
+    $('#id_dialect option').each(function(){
         $(this).attr('disabled','disabled');
     });
-    $('#id_dialects option').each(function(){
+    $('#id_dialect option').each(function(){
         var this_node_str = $(this).html();
         for(k = 0; k < optionValues.length; k++) {
             if (this_node_str.startsWith(optionValues[k])) {
@@ -92,10 +92,10 @@ function set_signlanguages_dialects() {
             }
         };
     });
-    $('#id_dialects').select2({
+    $('#id_dialect').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve'
      });
-    $('#id_dialects').val(null).trigger('change');
+    $('#id_dialect').val(null).trigger('change');
 };

--- a/signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html
@@ -153,8 +153,8 @@ $(document).ready(function() {
      <!--Django was messing up the template generation otherwise (without the uppercase L)-->
      <!--The value field is signlanguage[] (lowercase l to match the model)-->
 
-     makeMultipleSelect('id_signLanguage', 'signlanguage[]');
-     $('#id_signLanguage').select2({
+     makeMultipleSelect('id_signlanguage', 'signlanguage[]');
+     $('#id_signlanguage').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -163,21 +163,21 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('signlanguage[]')) {
          var query_initial = query_parameters_dict['signlanguage[]'];
-         $('#id_signLanguage').val(query_initial);
-         $('#id_signLanguage').trigger('change');
+         $('#id_signlanguage').val(query_initial);
+         $('#id_signlanguage').trigger('change');
      } else {
-         $('#id_signLanguage').val(null).trigger('change');
+         $('#id_signlanguage').val(null).trigger('change');
      };
 
-     $('#id_signLanguage').change(function() {
+     $('#id_signlanguage').change(function() {
         set_signlanguages_dialects();
      });
 
      <!--Alert: the id for the dialect field is dialects (plural), not the same as the model field!-->
      <!--Django was messing up the template generation otherwise (without the s at the end)-->
 
-     makeMultipleSelect('id_dialects', 'dialect[]');
-     $('#id_dialects').select2({
+     makeMultipleSelect('id_dialect', 'dialect[]');
+     $('#id_dialect').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -186,10 +186,10 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('dialect[]')) {
          var query_initial = query_parameters_dict['dialect[]'];
-         $('#id_dialects').val(query_initial);
-         $('#id_dialects').trigger('change');
+         $('#id_dialect').val(query_initial);
+         $('#id_dialect').trigger('change');
     } else {
-         $('#id_dialects').val(null).trigger('change');
+         $('#id_dialect').val(null).trigger('change');
     };
 
      makeMultipleSelect('id_tags', 'tags[]');
@@ -614,12 +614,12 @@ function do_toggle_language(el) {
                         <div id='searchbasic' class='collapse-light collapse'>
                         <table class='table table-condensed table-condensed-light' style="width:65%;">
                             <tr id='signlanguage_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signLanguage.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{searchform.signLanguage}}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signlanguage.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{searchform.signlanguage}}</td>
                             </tr>
                             <tr id='dialect_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialects.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{searchform.dialects}}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialect.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{searchform.dialect}}</td>
                             </tr>
                         </table>
 

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -192,8 +192,8 @@ $(document).ready(function() {
      <!--Django was messing up the template generation otherwise (without the uppercase L)-->
      <!--The value field is signlanguage[] (lowercase l to match the model)-->
 
-     makeMultipleSelect('id_signLanguage', 'signlanguage[]');
-     $('#id_signLanguage').select2({
+     makeMultipleSelect('id_signlanguage', 'signlanguage[]');
+     $('#id_signlanguage').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -203,21 +203,21 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('signlanguage[]')) {
          var query_initial = query_parameters_dict['signlanguage[]'];
-         $('#id_signLanguage').val(query_initial);
-         $('#id_signLanguage').trigger('change');
+         $('#id_signlanguage').val(query_initial);
+         $('#id_signlanguage').trigger('change');
      } else {
-         $('#id_signLanguage').val(null).trigger('change');
+         $('#id_signlanguage').val(null).trigger('change');
      };
 
-     $('#id_signLanguage').change(function() {
+     $('#id_signlanguage').change(function() {
         set_signlanguages_dialects();
      });
 
      <!--Alert: the id for the dialect field is dialects (plural), not the same as the model field!-->
      <!--Django was messing up the template generation otherwise (without the s at the end)-->
 
-     makeMultipleSelect('id_dialects', 'dialect[]');
-     $('#id_dialects').select2({
+     makeMultipleSelect('id_dialect', 'dialect[]');
+     $('#id_dialect').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -227,10 +227,10 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('dialect[]')) {
          var query_initial = query_parameters_dict['dialect[]'];
-         $('#id_dialects').val(query_initial);
-         $('#id_dialects').trigger('change');
+         $('#id_dialect').val(query_initial);
+         $('#id_dialect').trigger('change');
     } else {
-         $('#id_dialects').val(null).trigger('change');
+         $('#id_dialect').val(null).trigger('change');
     };
 
      function identityOption(optionNode) {
@@ -784,12 +784,12 @@ function do_toggle_language(el) {
                         <div id='searchbasic' class='collapse-light collapse'>
                         <table class='table table-condensed table-condensed-light' style="width:65%;">
                             <tr id='signlanguage_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signLanguage.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{ searchform.signLanguage }}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signlanguage.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{ searchform.signlanguage }}</td>
                             </tr>
                             <tr id='dialect_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialects.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{ searchform.dialects }}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialect.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{ searchform.dialect }}</td>
                             </tr>
                             {% for fieldname,field,label in input_names_fields_and_labels.main %}
                                 {% if not public or fieldname in PUBLIC_MAIN_FIELDS %}

--- a/signbank/dictionary/templates/dictionary/admin_senses_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_senses_list.html
@@ -168,8 +168,8 @@ $(document).ready(function() {
      <!--Django was messing up the template generation otherwise (without the uppercase L)-->
      <!--The value field is signlanguage[] (lowercase l to match the model)-->
 
-     makeMultipleSelect('id_signLanguage', 'signlanguage[]');
-     $('#id_signLanguage').select2({
+     makeMultipleSelect('id_signlanguage', 'signlanguage[]');
+     $('#id_signlanguage').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -178,21 +178,21 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('signlanguage[]')) {
          var query_initial = query_parameters_dict['signlanguage[]'];
-         $('#id_signLanguage').val(query_initial);
-         $('#id_signLanguage').trigger('change');
+         $('#id_signlanguage').val(query_initial);
+         $('#id_signlanguage').trigger('change');
      } else {
-         $('#id_signLanguage').val(null).trigger('change');
+         $('#id_signlanguage').val(null).trigger('change');
      };
 
-     $('#id_signLanguage').change(function() {
+     $('#id_signlanguage').change(function() {
         set_signlanguages_dialects();
      });
 
      <!--Alert: the id for the dialect field is dialects (plural), not the same as the model field!-->
      <!--Django was messing up the template generation otherwise (without the s at the end)-->
 
-     makeMultipleSelect('id_dialects', 'dialect[]');
-     $('#id_dialects').select2({
+     makeMultipleSelect('id_dialect', 'dialect[]');
+     $('#id_dialect').select2({
         allowClear: true,
         dropdownAutoWidth: true,
         width: 'resolve',
@@ -201,10 +201,10 @@ $(document).ready(function() {
 
      if (query_parameters_keys.includes('dialect[]')) {
          var query_initial = query_parameters_dict['dialect[]'];
-         $('#id_dialects').val(query_initial);
-         $('#id_dialects').trigger('change');
+         $('#id_dialect').val(query_initial);
+         $('#id_dialect').trigger('change');
     } else {
-         $('#id_dialects').val(null).trigger('change');
+         $('#id_dialect').val(null).trigger('change');
     };
      function identityOption(optionNode) {
         var color_text = optionNode.text;
@@ -616,12 +616,12 @@ function do_toggle_language(el) {
                         <div id='searchbasic' class='collapse-light collapse'>
                         <table class='table table-condensed table-condensed-light' style="width:65%;">
                             <tr id='signlanguage_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signLanguage.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{searchform.signLanguage}}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.signlanguage.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{searchform.signlanguage}}</td>
                             </tr>
                             <tr id='dialect_selection'>
-                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialects.label}}</label></td>
-                                <td class='td td-light' style="width:600px;">{{searchform.dialects}}</td>
+                                <td class='td td-light' style="padding-left:30px;"><label>{{searchform.dialect.label}}</label></td>
+                                <td class='td td-light' style="width:600px;">{{searchform.dialect}}</td>
                             </tr>
                         </table>
 

--- a/signbank/query_parameters.py
+++ b/signbank/query_parameters.py
@@ -748,13 +748,13 @@ def query_parameters_toggle_fields(query_parameters):
         if query_field == 'search_type':
             # don't show a button for this
             continue
-        if query_field in GlossSearchForm.get_field_names():
-            toggle_query_parameter = (query_field,
-                                      GlossSearchForm.get_field(query_field).label.encode('utf-8').decode())
-        elif query_field == 'dialect':
+        if query_field == 'dialect':
             toggle_query_parameter = (query_field, _("Dialect"))
         elif query_field == 'signlanguage':
             toggle_query_parameter = (query_field, _("Sign Language"))
+        elif query_field in GlossSearchForm.get_field_names():
+            toggle_query_parameter = (query_field,
+                                      GlossSearchForm.get_field(query_field).label.encode('utf-8').decode())
         elif query_field == 'sentenceType':
             toggle_query_parameter = (query_field, _("Sentence Type"))
         elif query_field == 'negative':
@@ -1026,15 +1026,15 @@ def set_up_signlanguage_dialects_fields(view, form):
     selected_datasets = get_selected_datasets(view.request)
     field_label_signlanguage = gettext("Sign Language")
     field_label_dialects = gettext("Dialect")
-    form.fields['signLanguage'] = forms.ModelMultipleChoiceField(label=field_label_signlanguage,
+    form.fields['signlanguage'] = forms.ModelMultipleChoiceField(label=field_label_signlanguage,
                                                                  widget=Select2,
                                                                  queryset=SignLanguage.objects.filter(
-                                                                     dataset__in=selected_datasets).distinct())
+                                                                 dataset__in=selected_datasets).distinct())
 
-    form.fields['dialects'] = forms.ModelMultipleChoiceField(label=field_label_dialects,
-                                                             widget=Select2,
-                                                             queryset=Dialect.objects.filter(
-                                                                 signlanguage__dataset__in=selected_datasets))
+    form.fields['dialect'] = forms.ModelMultipleChoiceField(label=field_label_dialects,
+                                                            widget=Select2,
+                                                            queryset=Dialect.objects.filter(
+                                                            signlanguage__dataset__in=selected_datasets))
 
 
 def legitimate_search_form_url_parameter(searchform, get_key):


### PR DESCRIPTION
Use model names for `signlanguage` and `dialect` in forms and templates.