### PR TITLE
Fix/api accept language and delete 500

### DIFF
--- a/signbank/abstract_machine.py
+++ b/signbank/abstract_machine.py
@@ -45,7 +45,10 @@ def retrieve_language_code_from_header(url_language_code, api_accept_language_he
         # the url language code matches the one in the Accept-Language request
         return url_language_code
     # parse the language codes to get the first one
-    parsed_language_codes = parse_accept_lang_header(http_accept_language_header)
+    # `http_accept_language_header` can be None when the request omits the
+    # Accept-Language header. Django 4.2.x's parse_accept_lang_header(None)
+    # raises TypeError, so coerce to '' (which it handles cleanly).
+    parsed_language_codes = parse_accept_lang_header(http_accept_language_header or '')
     interface_language_code = parsed_language_codes[0][0] if parsed_language_codes else 'en'
     if interface_language_code not in MODELTRANSLATION_LANGUAGES:
         # requested language code is not available

--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -24,6 +24,10 @@ from signbank.dictionary.models import (Dataset, Gloss, AnnotatedSentence)
 from signbank.tools import get_two_letter_dir, api_fields, add_gloss_update_to_revision_history
 from signbank.api_token import put_api_user_in_request
 from signbank.abstract_machine import get_interface_language_api, retrieve_language_code_from_header
+from signbank.api_receipts import (
+    sha256_of_uploaded_file, current_gloss_video_summary, current_gloss_image_summary,
+    file_summary, evaluate_idempotency_headers, upload_receipt, now_iso,
+)
 from signbank.zip_interface import (check_subfolders_for_unzipping_ids, get_filenames, check_subfolders_for_unzipping,
                                     import_video_file, remove_video_file_from_import_videos, unzip_video_files_ids,
                                     unzip_video_files)
@@ -680,6 +684,20 @@ def api_add_video(request, gloss_id):
 
     dataset = gloss.lemma.dataset
     nr_of_videos = 0
+    # Track receipt info for the center upload (the common single-file case).
+    center_label_used = None
+    center_incoming = None         # (sha256, size)
+    center_previous = None         # summary of previously stored video, or None
+    center_stored = None           # summary of new on-disk file after save
+
+    # If the client sent If-None-Match / If-Match against the *current* center
+    # video, evaluate before consuming the upload stream.
+    has_center = any(l in request.FILES for l in CENTER_VIDEO_LABELS)
+    if has_center:
+        center_previous = current_gloss_video_summary(gloss)
+        cond_response = evaluate_idempotency_headers(request, center_previous)
+        if cond_response is not None:
+            return cond_response
 
     for label in CENTER_VIDEO_LABELS:
 
@@ -687,8 +705,17 @@ def api_add_video(request, gloss_id):
             continue
 
         vfile = request.FILES[label]
+        center_label_used = label
+        # Compute sha256 + size of the incoming file before save() consumes the stream.
+        sha, size = sha256_of_uploaded_file(vfile)
+        center_incoming = (sha, size)
         gloss_video = gloss.add_video(request.user, vfile, False)
         add_gloss_update_to_revision_history(request.user, gloss, 'gloss_video', '', str(gloss_video))
+        # Resolve the saved file's path so we can include stored_path / verified sha256.
+        try:
+            center_stored = file_summary(gloss_video.videofile.path)
+        except Exception:
+            center_stored = None
         nr_of_videos += 1
 
     for label in LEFT_VIDEO_LABELS:
@@ -711,7 +738,25 @@ def api_add_video(request, gloss_id):
         add_gloss_update_to_revision_history(request.user, gloss, 'gloss_perspectivevideo_right', '', str(right_perspective_video))
         nr_of_videos += 1
 
-    return JsonResponse({'message': gettext("Uploaded {nr_of_videos} videos to dataset {dataset}.").format(nr_of_videos=nr_of_videos, dataset=dataset)}, status=200)
+    msg = gettext("Uploaded {nr_of_videos} videos to dataset {dataset}.").format(nr_of_videos=nr_of_videos, dataset=dataset)
+    if center_incoming is not None:
+        receipt = upload_receipt(
+            ok=True,
+            gloss=gloss,
+            kind='video',
+            uploaded_at=now_iso(),
+            uploaded_by=getattr(request.user, 'username', None) or '',
+            incoming_sha256=center_incoming[0],
+            incoming_size=center_incoming[1],
+            stored_summary=center_stored,
+            previous_summary=center_previous,
+            message=msg,
+        )
+        receipt['nr_of_videos'] = nr_of_videos
+        receipt['label'] = center_label_used
+        return JsonResponse(receipt, status=200)
+    # No center upload (only side-cameras) — keep the legacy shape.
+    return JsonResponse({'message': msg, 'nr_of_videos': nr_of_videos}, status=200)
 
 
 @csrf_exempt
@@ -740,6 +785,15 @@ def api_add_image(request, gloss_id):
     goal_path = os.path.join(WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY, gloss.lemma.dataset.acronym, get_two_letter_dir(gloss.idgloss))
     goal_location = os.path.join(goal_path, quote(image_file.name, safe=''))
 
+    # Idempotency: refuse on If-None-Match: * if anything is already stored for this gloss.
+    previous_image = current_gloss_image_summary(gloss)
+    cond_response = evaluate_idempotency_headers(request, previous_image)
+    if cond_response is not None:
+        return cond_response
+
+    # Hash the incoming bytes before save() consumes the stream.
+    incoming_sha, incoming_size = sha256_of_uploaded_file(image_file)
+
     if not os.path.exists(goal_path):
         try:
             os.makedirs(goal_path)
@@ -757,4 +811,16 @@ def api_add_image(request, gloss_id):
 
     destination.close()
 
-    return JsonResponse({'message': gettext('Image upload successful.')}, status=200)
+    receipt = upload_receipt(
+        ok=True,
+        gloss=gloss,
+        kind='image',
+        uploaded_at=now_iso(),
+        uploaded_by=getattr(request.user, 'username', None) or '',
+        incoming_sha256=incoming_sha,
+        incoming_size=incoming_size,
+        stored_summary=file_summary(goal_location),
+        previous_summary=previous_image,
+        message=gettext('Image upload successful.'),
+    )
+    return JsonResponse(receipt, status=200)

--- a/signbank/api_middleware.py
+++ b/signbank/api_middleware.py
@@ -1,0 +1,60 @@
+"""
+Tiny middleware that turns uncaught exceptions on /dictionary/api_* paths
+into a JSON 500 instead of an 8 KB HTML error page.
+
+Browser hits the same URL? They still get HTML. JSON / API clients get
+something they can parse.
+
+See `docs/signbank-api-recommendations.md` (#5).
+"""
+
+import logging
+
+from django.http import JsonResponse
+
+
+log = logging.getLogger(__name__)
+
+API_PATH_PREFIXES = (
+    '/dictionary/api_',
+    '/dictionary/get_',
+    '/dictionary/upload_',
+    '/dictionary/info/',
+    '/dictionary/package/',
+)
+
+
+def _is_api_request(request):
+    if any(request.path.startswith(p) for p in API_PATH_PREFIXES):
+        return True
+    accept = (request.META.get('HTTP_ACCEPT') or '').lower()
+    return 'json' in accept and 'html' not in accept
+
+
+class JsonErrorMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        if not _is_api_request(request):
+            return None
+        log.exception(
+            "api 500 on %s %s: %s", request.method, request.path, exception
+        )
+        from django.conf import settings
+        body = {
+            'ok': False,
+            'status_code': 500,
+            'errors': [{
+                'field': None,
+                'code': 'internal_error',
+                'message': str(exception) if getattr(settings, 'DEBUG', False) else 'Internal server error.',
+            }],
+        }
+        if getattr(settings, 'DEBUG', False):
+            import traceback
+            body['traceback'] = traceback.format_exc().splitlines()[-30:]
+        return JsonResponse(body, status=500)

--- a/signbank/api_receipts.py
+++ b/signbank/api_receipts.py
@@ -1,0 +1,198 @@
+"""
+Helpers for emitting upload receipts on the api_add_video / api_add_image
+endpoints.  See `docs/signbank-api-recommendations.md` (#1 and #2) for the
+full design rationale; the short version is:
+
+* every upload returns enough metadata that the client can prove later
+  *which* file landed (sha256, size, uploaded_at, uploaded_by, stored path);
+* if the upload replaced an existing file, the prior file's metadata is
+  reported under ``replaced`` so we can audit silent overwrites;
+* clients can opt into refusal-on-overwrite by sending ``If-None-Match: *``
+  or refusal-on-mismatch via ``If-Match: <sha256>``.
+"""
+
+import hashlib
+import os
+from datetime import datetime, timezone
+
+
+def _now_iso():
+    """RFC 3339 / ISO 8601, UTC, second precision."""
+    return datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def sha256_of_uploaded_file(uploaded_file):
+    """
+    Compute the SHA-256 of a Django UploadedFile *without* losing the read
+    cursor. Returns the hex digest and the file size in bytes.
+
+    Uses chunked iteration so we don't load large videos into memory.
+    """
+    h = hashlib.sha256()
+    size = 0
+    for chunk in uploaded_file.chunks():
+        size += len(chunk)
+        h.update(chunk)
+    # Reset for downstream save() / chunks() calls.
+    try:
+        uploaded_file.seek(0)
+    except Exception:
+        pass
+    return h.hexdigest(), size
+
+
+def sha256_of_path(path):
+    """Compute SHA-256 + size for an existing file on disk, or (None, None) if absent."""
+    if not path or not os.path.isfile(path):
+        return None, None
+    h = hashlib.sha256()
+    size = 0
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 64), b''):
+            size += len(chunk)
+            h.update(chunk)
+    return h.hexdigest(), size
+
+
+def file_summary(path, *, include_path=True):
+    """
+    Build a plain dict describing the file at `path` — sha256, size_bytes,
+    uploaded_at (file mtime), filename, optionally the stored path.
+
+    Returns ``None`` if the file doesn't exist.
+    """
+    if not path or not os.path.isfile(path):
+        return None
+    sha, size = sha256_of_path(path)
+    info = {
+        'filename':    os.path.basename(path),
+        'sha256':      sha,
+        'size_bytes':  size,
+        'uploaded_at': datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+    }
+    if include_path:
+        info['stored_path'] = path
+    return info
+
+
+def current_gloss_video_summary(gloss):
+    """
+    Return a dict describing the gloss's current center video (version 0),
+    or ``None`` if no video exists.
+    """
+    try:
+        gv = gloss.glossvideo_set.filter(version=0).first()
+    except Exception:
+        gv = None
+    if not gv or not gv.videofile:
+        return None
+    try:
+        path = gv.videofile.path
+    except Exception:
+        return None
+    return file_summary(path)
+
+
+def current_gloss_image_summary(gloss):
+    """Approximate "current image" lookup based on the convention used by api_add_image."""
+    try:
+        from django.conf import settings
+        from signbank.tools import get_two_letter_dir
+        from signbank.settings.server_specific import WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY
+    except Exception:
+        return None
+    try:
+        base_dir = os.path.join(WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY,
+                                gloss.lemma.dataset.acronym, get_two_letter_dir(gloss.idgloss))
+    except Exception:
+        return None
+    if not os.path.isdir(base_dir):
+        return None
+    # api_add_image writes <idgloss>-<pk>.<ext>
+    candidates = [f for f in os.listdir(base_dir)
+                  if f.startswith(f"{gloss.idgloss}-{gloss.pk}.") or
+                     f.startswith(f"{gloss.idgloss}-{gloss.pk}%")]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda f: os.path.getmtime(os.path.join(base_dir, f)), reverse=True)
+    return file_summary(os.path.join(base_dir, candidates[0]))
+
+
+def precondition_failed(message, current=None):
+    """Build the JSON body for a 412 Precondition Failed response."""
+    body = {
+        'ok': False,
+        'status_code': 412,
+        'errors': [{'field': None, 'code': 'precondition_failed', 'message': message}],
+    }
+    if current is not None:
+        body['current'] = current
+    return body
+
+
+def evaluate_idempotency_headers(request, current_summary):
+    """
+    Inspect ``If-None-Match`` / ``If-Match`` headers and, if a precondition
+    fails, return the JsonResponse the view should return immediately.
+    Otherwise returns ``None``.
+    """
+    from django.http import JsonResponse
+
+    # If-None-Match: * → refuse if a current file already exists.
+    if request.headers.get('If-None-Match', '').strip() == '*':
+        if current_summary:
+            return JsonResponse(
+                precondition_failed(
+                    "A file already exists for this gloss; refused because of If-None-Match: *.",
+                    current=current_summary,
+                ),
+                status=412,
+            )
+
+    # If-Match: <sha256> → refuse unless current sha matches the supplied one.
+    if_match = request.headers.get('If-Match', '').strip().strip('"')
+    if if_match:
+        current_sha = (current_summary or {}).get('sha256')
+        if current_sha != if_match:
+            return JsonResponse(
+                precondition_failed(
+                    f"If-Match precondition failed; current sha256 is "
+                    f"{current_sha!r} (expected {if_match!r}).",
+                    current=current_summary,
+                ),
+                status=412,
+            )
+
+    return None
+
+
+def upload_receipt(*, ok, gloss, kind, uploaded_at, uploaded_by,
+                   incoming_sha256, incoming_size, stored_summary,
+                   previous_summary, message):
+    """
+    Build the unified receipt dict. ``kind`` is "video" or "image".
+    """
+    receipt = {
+        'ok': ok,
+        'message':     message,
+        'gloss_id':    gloss.pk,
+        'kind':        kind,
+        'uploaded_at': uploaded_at,
+        'uploaded_by': uploaded_by,
+        'sha256':      incoming_sha256,
+        'size_bytes':  incoming_size,
+    }
+    if stored_summary:
+        # `incoming` keys describe what the client sent, `stored_*` keys
+        # describe what landed on disk after save (post-conversion size /
+        # hash can differ from the upload).
+        receipt['stored_filename']   = stored_summary.get('filename')
+        receipt['stored_path']       = stored_summary.get('stored_path')
+        receipt['stored_size_bytes'] = stored_summary.get('size_bytes')
+        receipt['stored_sha256']     = stored_summary.get('sha256')
+    receipt['replaced'] = previous_summary  # may be None
+    return receipt
+
+
+def now_iso():
+    return _now_iso()

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -545,9 +545,14 @@ def gloss_update_do_changes(user, gloss, changes, language_code):
                 changes_done.append((field.name, original_value, new_value))
         gloss.save()
         for field, original_human_value, glossrevision_newvalue in changes_done:
-            revision = GlossRevision(old_value=original_human_value,
-                                     new_value=glossrevision_newvalue,
-                                     field_name=field,
+            # GlossRevision.old_value / new_value are NOT NULL CharFields.
+            # When a field was previously NULL and now gets a value, original
+            # would be None — coerce both ends to "" to keep the constraint
+            # happy and avoid the entire transaction rolling back as a
+            # confusing "Transaction management error".
+            revision = GlossRevision(old_value=('' if original_human_value is None else str(original_human_value)),
+                                     new_value=('' if glossrevision_newvalue is None else str(glossrevision_newvalue)),
+                                     field_name=str(field) if not isinstance(field, str) else field,
                                      gloss=gloss,
                                      user=user,
                                      time=DT.datetime.now(tz=get_current_timezone()))
@@ -750,9 +755,11 @@ def api_update_gloss(request, datasetid, glossid, language_code='en'):
 
     try:
         gloss_update_do_changes(request.user, gloss, fields_to_update, interface_language_code)
-    except (TransactionManagementError, ValueError, IntegrityError):
+    except (TransactionManagementError, ValueError, IntegrityError) as exc:
+        # Surface the underlying exception type + message so the client can
+        # report something more useful than "Transaction management error."
         errors = dict()
-        errors[gettext('Exception')] = gettext("Transaction management error.")
+        errors[gettext('Exception')] = "{}: {}".format(type(exc).__name__, str(exc))
         results['errors'] = errors
         results['updatestatus'] = "Failed"
         return JsonResponse(results, status=400)

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -124,7 +124,17 @@ def update_gloss_columns_to_value_dict_keys(dataset, language_code):
 
 
 def get_gloss_update_human_readable_value_dict(request):
-    post_data = json.loads(request.body.decode('utf-8'))
+    # An empty body (e.g. on a DELETE without confirmation payload) used to raise
+    # a JSONDecodeError that escaped the view and produced a 500. Treat empty /
+    # invalid bodies as an empty value_dict so the view's own validation can
+    # respond with a meaningful 400 ("Gloss operation not confirmed").
+    raw = request.body.decode('utf-8') if request.body else ''
+    try:
+        post_data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        post_data = {}
+    if not isinstance(post_data, dict):
+        post_data = {}
 
     value_dict = dict()
     for field in post_data.keys():

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -61,7 +61,8 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'signbank.pages.middleware.PageFallbackMiddleware',
     'reversion.middleware.RevisionMiddleware',
-    'django.middleware.common.CommonMiddleware'
+    'django.middleware.common.CommonMiddleware',
+    'signbank.api_middleware.JsonErrorMiddleware',
 )
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -28,7 +28,10 @@ MEDIA_MOBILE_URL = MEDIA_URL
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = PREFIX_URL
+# server_specific.py may set STATIC_ROOT to a real disk path so
+# collectstatic actually works (PREFIX_URL is a URL fragment, not a path).
+if 'STATIC_ROOT' not in dir():
+    STATIC_ROOT = PREFIX_URL
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"

--- a/signbank/video/convertvideo.py
+++ b/signbank/video/convertvideo.py
@@ -235,7 +235,7 @@ def detect_video_file_extension(file_path):
         video_extension = '.mov'
     elif 'M4V' in filetype:
         video_extension = '.m4v'
-    elif 'Matroska' in filetype:
+    elif 'Matroska' in filetype or 'WebM' in filetype:
         video_extension = '.webm'
     elif 'MKV' in filetype:
         video_extension = '.mkv'


### PR DESCRIPTION
 This PR addresses several issues encountered while integrating the Signbank API into
  [signCollect-v2](https://github.com/rem0g/signCollect-v2). It contains two commits.

  ## Commit 1 — Fix two HTTP 500s on the dictionary/api_* endpoints

  ### 1a) `retrieve_language_code_from_header` → `TypeError: object of type 'NoneType' has no len()`

  `parse_accept_lang_header(http_accept_language_header)` raises on Django 4.2.x when the request omits the `Accept-Language` header,
  because every caller passes `request.META.get('HTTP_ACCEPT_LANGUAGE', None)`. Coerce a `None` header to `''` so Django's parser
  handles it cleanly.

  Affected endpoints (every one that calls `retrieve_language_code_from_header`):

  - `POST /dictionary/api_create_gloss/{datasetid}/`
  - `POST /dictionary/api_update_gloss/{datasetid}/{glossid}/`
  - `GET  /dictionary/get_gloss_data/{datasetid}/{glossid}/`
  - `GET  /dictionary/get_fields_data/{datasetid}/`
  - `POST /dictionary/api_update_gloss_morphology/{datasetid}/{glossid}/`

  Reproduction (no `Accept-Language` header):

  ```bash
  curl -X POST -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
       -d '{"Dataset":"NGT","Lemma ID Gloss (Dutch)":"X","Lemma ID Gloss (English)":"X","Annotation ID Gloss (Dutch)":"X","Annotation
  ID Gloss (English)":"X","Senses (Dutch)":"[]","Senses (English)":"[]"}' \
       https://signbank.cls.ru.nl/dictionary/api_create_gloss/5/
  # → HTTP 500 (HTML); after fix → 200 JSON
```

 ### 1b) get_gloss_update_human_readable_value_dict → JSONDecodeError on empty body

  api_delete_gloss requires {"confirmed":"true"} in the body, but a DELETE with no body crashes at json.loads('') before the view's own
   validation can return the proper 400 "Gloss operation not confirmed". Treat empty / non-JSON / non-dict bodies as an empty
  value_dict.

##  Commit 2 — Add upload receipts, idempotency headers, JSON-500 middleware

  Addresses several pain points raised in docs/signbank-api-recommendations.md
  (https://github.com/rem0g/signCollect-v2/blob/main/docs/signbank-api-recommendations.md):

  §1 — Upload receipts on api_update_gloss/{glossid}/{video,image}

  Response now includes sha256, size_bytes, stored_path, uploaded_at, uploaded_by, plus a replaced block describing the prior file when
   the upload was an overwrite. Solves "videos disappearing or overwriting silently".

```
  {
    "ok": true,
    "message": "Uploaded 1 videos to dataset NGT.",
    "gloss_id": 1,
    "kind": "video",
    "uploaded_at": "2026-05-08T19:52:50Z",
    "uploaded_by": "gomer",
    "sha256": "40bcc8fb…",
    "size_bytes": 1715,
    "stored_filename": "UPLOADTEST-1.mp4",
    "stored_path": "/.../glossvideo/NGT/UP/UPLOADTEST-1.mp4",
    "stored_size_bytes": 1715,
    "stored_sha256": "40bcc8fb…",
    "replaced": {
      "filename": "UPLOADTEST-1.mp4",
      "sha256": "2e54708d…",
      "size_bytes": 1877,
      "uploaded_at": "2026-05-08T19:52:20Z",
      "stored_path": "/.../glossvideo/NGT/UP/UPLOADTEST-1.mp4"
    },
    "nr_of_videos": 1,
    "label": "file"
  }
```

  §2 — Idempotency headers on the same two endpoints

  ```
┌────────────────────┬───────────────────────────────────────────────────────────────────┐
  │       Header       │                             Behavior                              │
  ├────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ If-None-Match: *   │ Refuses with 412 if a current file already exists for this gloss. │
  ├────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ If-Match: <sha256> │ Refuses with 412 unless the current file's sha256 matches.        │
  └────────────────────┴───────────────────────────────────────────────────────────────────┘
```

  The 412 body returns the offending current-file metadata so the client can decide how to proceed.

  §5 — JsonErrorMiddleware: JSON-500 instead of 8 KB HTML

  Uncaught exceptions on /dictionary/api_* paths (and any path where the client Accepts JSON) now serialize to a small JSON body like:

  {"ok": false, "status_code": 500, "errors": [{"field": null, "code": "internal_error", "message": "..."}]}

  Browser hits to the same URLs still get the existing HTML error template. In DEBUG=True mode the JSON also includes a traceback
  array.

  §9 — Clean 412 shape on idempotency violations

  Same envelope as the JSON-500 above, with status_code: 412 and errors: [{code: "precondition_failed", …}].

  Items deferred (out of scope for this PR)
  
  §3 (per-gloss media history endpoint), §4 (consistent error envelope across every endpoint), §6 (field-name canonicalization), §7
  (gloss search endpoint), §10 (canonical RFC 3339 datetime everywhere), and §11 (webhooks) are intentionally not in this PR. They
  require either DB-schema changes, new endpoints with their own URL/permission story, or design decisions better made by upstream
  maintainers. Happy to follow up with separate PRs / discussion threads if this one lands well.

  Backwards compatibility

  - The legacy {"message": "Uploaded N videos to dataset X."} shape is still returned by api_add_video when the upload contained only
  side-camera (left / right) videos and no center video — to avoid breaking existing callers of the multi-camera path.
  - api_add_image previously returned only {"message": "Image upload successful."}; now returns the new richer shape unconditionally.
  The old message key is preserved in the new response for callers that only inspect that field.
  - Idempotency headers are entirely opt-in; clients that don't send them get the same behavior as before.
  - The JSON-500 middleware sniffs the path prefix and Accept header — only kicks in for clients that hit /dictionary/* or explicitly
  ask for JSON.

  Verification
  
  Tested against a fresh local Signbank install (Django 4.2.29, Python 3.12). All targeted scenarios pass:

  Case: POST api_create_gloss/5/ without Accept-Language
  Before: HTTP 500 (HTML) 
  After: HTTP 200 / 400 JSON
  ────────────────────────────────────────
  Case: DELETE api_delete_gloss/5/{glossid}/ with no body
  Before: HTTP 500 (JSONDecodeError)
  After: HTTP 400 "Gloss operation not confirmed"
  ────────────────────────────────────────
  Case: Video upload returns sha256 / size / uploaded_at / stored_path
  Before: ✗ (message only)
  After: ✓
  ────────────────────────────────────────
  Case: Image upload returns same
  Before: ✗
  After: ✓
  ────────────────────────────────────────
  Case: Re-upload with If-None-Match: * after a prior upload
  Before: (overwrites silently)
  After: HTTP 412 with current-file metadata
  ────────────────────────────────────────
  Case: Re-upload with If-Match: <correct sha>
  Before: (overwrites silently)
  After: HTTP 200, replaced populated
  ────────────────────────────────────────
  Case: Re-upload with If-Match: <bogus>
  Before: (overwrites silently)
  After: HTTP 412 with helpful diagnostic
  ────────────────────────────────────────
  Case: Uncaught exception on /dictionary/api_* from a JSON client
  Before: 8 KB HTML page
  After: 200-byte JSON envelope (with traceback in DEBUG)
