### PR TITLE
Fix two HTTP 500s on /dictionary/api_* endpoints

### DIFF
--- a/signbank/abstract_machine.py
+++ b/signbank/abstract_machine.py
@@ -45,7 +45,7 @@ def retrieve_language_code_from_header(url_language_code, api_accept_language_he
         # the url language code matches the one in the Accept-Language request
         return url_language_code
     # parse the language codes to get the first one
-    parsed_language_codes = parse_accept_lang_header(http_accept_language_header)
+    parsed_language_codes = parse_accept_lang_header(http_accept_language_header or '')
     interface_language_code = parsed_language_codes[0][0] if parsed_language_codes else 'en'
     if interface_language_code not in MODELTRANSLATION_LANGUAGES:
         # requested language code is not available

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -124,7 +124,17 @@ def update_gloss_columns_to_value_dict_keys(dataset, language_code):
 
 
 def get_gloss_update_human_readable_value_dict(request):
-    post_data = json.loads(request.body.decode('utf-8'))
+    # An empty body (e.g. on a DELETE without confirmation payload) used to raise
+    # a JSONDecodeError that escaped the view and produced a 500. Treat empty /
+    # invalid bodies as an empty value_dict so the view's own validation can
+    # respond with a meaningful 400 ("Gloss operation not confirmed").
+    raw = request.body.decode('utf-8') if request.body else ''
+    try:
+        post_data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        post_data = {}
+    if not isinstance(post_data, dict):
+        post_data = {}
 
     value_dict = dict()
     for field in post_data.keys():

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -124,10 +124,8 @@ def update_gloss_columns_to_value_dict_keys(dataset, language_code):
 
 
 def get_gloss_update_human_readable_value_dict(request):
-    # An empty body (e.g. on a DELETE without confirmation payload) used to raise
-    # a JSONDecodeError that escaped the view and produced a 500. Treat empty /
-    # invalid bodies as an empty value_dict so the view's own validation can
-    # respond with a meaningful 400 ("Gloss operation not confirmed").
+    # Handle empty or invalid JSON bodies gracefully so the view's validation
+    # can respond with a meaningful error instead of a 500.
     raw = request.body.decode('utf-8') if request.body else ''
     try:
         post_data = json.loads(raw) if raw else {}


### PR DESCRIPTION
Two separate HTTP-500 bugs encountered while integrating the Signbank API into [signCollect-v2](https://github.com/rem0g/signCollect-v2).

### 1. `retrieve_language_code_from_header` → `TypeError` when `Accept-Language` omitted
`parse_accept_lang_header(http_accept_language_header)` (Django 4.2.29) raises `TypeError: object of type 'NoneType' has no len()` when the header is missing. Fix: coerce `None` to `''`, which Django handles cleanly.

### 2. `get_gloss_update_human_readable_value_dict` → `JSONDecodeError` on empty body
`json.loads(request.body.decode('utf-8'))` raises before the view's own validation can produce a meaningful 400. Fix: treat empty / invalid bodies as `{}` so the view's existing "Gloss operation not confirmed" 400 fires.

### Affected endpoints
- `api_update_gloss`, `api_create_gloss`, `api_delete_gloss` (and their `/nl/` variants)

Split out of #1743 per review.