### PR TITLE
Detect WebM uploads from plain "WebM" file(1) output

### DIFF
--- a/signbank/video/convertvideo.py
+++ b/signbank/video/convertvideo.py
@@ -235,7 +235,7 @@ def detect_video_file_extension(file_path):
         video_extension = '.mov'
     elif 'M4V' in filetype:
         video_extension = '.m4v'
-    elif 'Matroska' in filetype:
+    elif 'Matroska' in filetype or 'WebM' in filetype:
         video_extension = '.webm'
     elif 'MKV' in filetype:
         video_extension = '.mkv'


### PR DESCRIPTION
`file(1)` on Ubuntu 22.04 returns just `"WebM"` for some `.webm` uploads (no `"video/webm"` prefix). The existing match missed those, causing the upload to be rejected as an unknown format. Fix: also accept the plain `"WebM"` form.

Split out of #1743 per review.