### PR TITLE
Let server_specific.py override STATIC_ROOT

### DIFF
--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -28,7 +28,10 @@ MEDIA_MOBILE_URL = MEDIA_URL
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = PREFIX_URL
+# server_specific.py may set STATIC_ROOT to a real disk path so
+# collectstatic actually works (PREFIX_URL is a URL fragment, not a path).
+if 'STATIC_ROOT' not in dir():
+    STATIC_ROOT = PREFIX_URL
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"


### PR DESCRIPTION
`base.py` unconditionally set `STATIC_ROOT = PREFIX_URL` (a URL fragment like `/signbank_local`), so `collectstatic` would try to `mkdir` an absolute path under `/` and fail with `PermissionError` on any non-root install. Per-instance settings already override `URL` / `PREFIX_URL` etc; let them override `STATIC_ROOT` too with a real disk path.

No behaviour change unless `server_specific.py` defines `STATIC_ROOT`.

Split out of #1743 per review.