### PR TITLE
API upload receipts, idempotency headers, JSON-500 middleware + role-based verbose-errors gate

### DIFF
--- a/docs/signbank-api.json
+++ b/docs/signbank-api.json
@@ -37,6 +37,135 @@
         "scheme": "bearer",
         "in": "header"
       }
+    },
+    "schemas":
+    {
+      "FileSummary":
+      {
+        "type": "object",
+        "description": "Metadata about a file stored on the server.",
+        "properties":
+        {
+          "filename":    { "type": "string" },
+          "sha256":      { "type": "string", "description": "Hex SHA-256 of the stored file." },
+          "size_bytes":  { "type": "integer" },
+          "uploaded_at": { "type": "string", "format": "date-time", "description": "RFC 3339 / ISO 8601, UTC." },
+          "stored_path": { "type": "string", "description": "Absolute path on the server (omitted in some contexts)." }
+        }
+      },
+      "UploadReceipt":
+      {
+        "type": "object",
+        "description": "Returned by api_update_gloss/.../video and .../image on success (HTTP 200). All `stored_*` keys describe the file as it landed on disk; `incoming` sha256/size_bytes describe what the client uploaded. `replaced` is the prior file's FileSummary, or null.",
+        "properties":
+        {
+          "ok":                { "type": "boolean" },
+          "message":           { "type": "string" },
+          "gloss_id":          { "type": "integer" },
+          "kind":              { "type": "string", "enum": ["video", "image"] },
+          "uploaded_at":       { "type": "string", "format": "date-time" },
+          "uploaded_by":       { "type": "string", "description": "Username of the API user." },
+          "sha256":            { "type": "string", "description": "Hex SHA-256 of the incoming upload." },
+          "size_bytes":        { "type": "integer", "description": "Bytes received from the client." },
+          "stored_filename":   { "type": "string" },
+          "stored_path":       { "type": "string" },
+          "stored_size_bytes": { "type": "integer", "description": "Bytes on disk after save (may differ from incoming after conversion)." },
+          "stored_sha256":     { "type": "string", "description": "SHA-256 of the file on disk after save." },
+          "replaced":
+          {
+            "description": "FileSummary for the prior file at this slot, or null when nothing was replaced.",
+            "oneOf":
+            [
+              { "$ref": "#/components/schemas/FileSummary" },
+              { "type": "null" }
+            ]
+          },
+          "nr_of_videos": { "type": "integer", "description": "Only present on the video endpoint." },
+          "label":        { "type": "string", "description": "Form field name that the video came in under — `file`, `center`, `left`, `right`." }
+        },
+        "required": ["ok", "gloss_id", "kind", "uploaded_at", "uploaded_by", "sha256", "size_bytes"]
+      },
+      "ApiError":
+      {
+        "type": "object",
+        "description": "Uniform error body returned by the JsonErrorMiddleware and by precondition checks. `errors[].message` contains the raw Python exception text only when the caller has DEBUG enabled or belongs to the `Verbose API Errors` group; otherwise it is a generic message.",
+        "properties":
+        {
+          "ok":          { "type": "boolean", "enum": [false] },
+          "status_code": { "type": "integer" },
+          "errors":
+          {
+            "type": "array",
+            "items":
+            {
+              "type": "object",
+              "properties":
+              {
+                "field":   { "type": ["string", "null"] },
+                "code":    { "type": "string", "description": "Machine-readable error code, e.g. `internal_error` or `precondition_failed`." },
+                "message": { "type": "string" }
+              },
+              "required": ["code", "message"]
+            }
+          },
+          "current":
+          {
+            "description": "On 412 responses: FileSummary of what the server currently has, so the client can re-attempt with the correct ETag.",
+            "$ref": "#/components/schemas/FileSummary"
+          },
+          "traceback":
+          {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Only present when verbose errors are enabled."
+          }
+        },
+        "required": ["ok", "status_code", "errors"]
+      }
+    },
+    "parameters":
+    {
+      "IfMatchHeader":
+      {
+        "name": "If-Match",
+        "in": "header",
+        "required": false,
+        "description": "Comma-separated list of quoted ETag values (sha256 of the file). The upload is refused with 412 unless the server's current sha256 matches one of them. Use `*` to require that a file is already stored.",
+        "schema": { "type": "string", "example": "\"a1b2…\", \"c3d4…\"" }
+      },
+      "IfNoneMatchHeader":
+      {
+        "name": "If-None-Match",
+        "in": "header",
+        "required": false,
+        "description": "Send `*` to refuse the upload with 412 if anything is already stored for this gloss.",
+        "schema": { "type": "string", "example": "*" }
+      }
+    },
+    "responses":
+    {
+      "PreconditionFailed":
+      {
+        "description": "Idempotency precondition (If-Match / If-None-Match) was not met. Body includes the server's current FileSummary so the client can resync.",
+        "content":
+        {
+          "application/json":
+          {
+            "schema": { "$ref": "#/components/schemas/ApiError" }
+          }
+        }
+      },
+      "InternalError":
+      {
+        "description": "Uncaught server exception, normalised to JSON by JsonErrorMiddleware. The detailed Python exception text is only included for users with verbose errors enabled.",
+        "content":
+        {
+          "application/json":
+          {
+            "schema": { "$ref": "#/components/schemas/ApiError" }
+          }
+        }
+      }
     }
   },
   "paths":
@@ -1210,66 +1339,75 @@
         ]
       }
     },
-    "/dictionary/api_update_gloss/{glossid}/video": 
+    "/dictionary/api_update_gloss/{glossid}/video":
     {
-      "post": 
+      "post":
       {
-        "description": "Updates the video of a gloss.",
-        "parameters": 
+        "description": "Updates the video of a gloss. On success returns an UploadReceipt with sha256 + size of the incoming and stored files and a FileSummary of the file that was replaced (if any). Honors If-Match / If-None-Match for idempotency.",
+        "parameters":
         [
           {
             "name": "glossid",
             "in": "path",
             "description": "ID of the gloss to be updated",
             "required": true,
-            "schema": 
+            "schema":
             {
               "type": "string"
             }
-          }
+          },
+          { "$ref": "#/components/parameters/IfMatchHeader" },
+          { "$ref": "#/components/parameters/IfNoneMatchHeader" }
         ],
         "requestBody":
         {
-          "content": 
+          "content":
           {
-            "multipart/form-data": 
+            "multipart/form-data":
             {
-              "schema": 
+              "schema":
               {
                 "type": "object",
-                "properties": 
+                "properties":
                 {
-                  "center": 
+                  "center":
                   {
                     "type": "string",
-                    "format": "binary", 
+                    "format": "binary",
                     "description": "The video file to upload, default/mid camera perspective/"
                   },
-                  "left": 
+                  "left":
                   {
                     "type": "string",
-                    "format": "binary", 
+                    "format": "binary",
                     "description": "The video file to upload, left camera perspective."
                   },
-                  "right": 
+                  "right":
                   {
                     "type": "string",
-                    "format": "binary", 
+                    "format": "binary",
                     "description": "The video file to upload, right camera perspective."
                   }
                 },
-                "required": 
+                "required":
                 [
                 ]
               }
             }
           }
         },
-        "responses": 
+        "responses":
         {
-          "200": 
+          "200":
           {
-            "description": "Update successful"
+            "description": "Update successful",
+            "content":
+            {
+              "application/json":
+              {
+                "schema": { "$ref": "#/components/schemas/UploadReceipt" }
+              }
+            }
           },
           "400":
           {
@@ -1286,10 +1424,18 @@
           "404":
           {
             "description": "Gloss not found"
+          },
+          "412":
+          {
+            "$ref": "#/components/responses/PreconditionFailed"
+          },
+          "500":
+          {
+            "$ref": "#/components/responses/InternalError"
           }
         },
         "tags": ["Updating Signbank data"],
-        "security": 
+        "security":
         [
           {
             "bearerAuth": []
@@ -1301,7 +1447,7 @@
     {
       "post":
       {
-        "description": "Updates the image of a gloss.",
+        "description": "Updates the image of a gloss. On success returns an UploadReceipt with sha256 + size of the incoming and stored files and a FileSummary of the file that was replaced (if any). Honors If-Match / If-None-Match for idempotency.",
         "parameters":
         [
           {
@@ -1313,7 +1459,9 @@
             {
               "type": "string"
             }
-          }
+          },
+          { "$ref": "#/components/parameters/IfMatchHeader" },
+          { "$ref": "#/components/parameters/IfNoneMatchHeader" }
         ],
         "requestBody":
         {
@@ -1344,7 +1492,14 @@
         {
           "200":
           {
-            "description": "Update successful"
+            "description": "Update successful",
+            "content":
+            {
+              "application/json":
+              {
+                "schema": { "$ref": "#/components/schemas/UploadReceipt" }
+              }
+            }
           },
           "400":
           {
@@ -1361,6 +1516,14 @@
           "404":
           {
             "description": "Gloss not found"
+          },
+          "412":
+          {
+            "$ref": "#/components/responses/PreconditionFailed"
+          },
+          "500":
+          {
+            "$ref": "#/components/responses/InternalError"
           }
         },
         "tags": ["Updating Signbank data"],

--- a/signbank/api_errors.py
+++ b/signbank/api_errors.py
@@ -1,0 +1,44 @@
+"""
+Helpers for shaping error responses returned by the API.
+
+Not all clients holding a valid API token can be trusted with raw Python
+exception text — internal paths, query fragments and other sensitive data
+may leak through ``str(exc)``. ``has_verbose_errors`` decides who gets the
+detail; ``safe_error_message`` returns the appropriate string for the
+caller. See PR #1743 (Wessel/Micha review thread) for the discussion.
+"""
+
+from django.conf import settings
+
+
+VERBOSE_ERRORS_GROUP = 'Verbose API Errors'
+
+GENERIC_ERROR_MESSAGE = 'Internal server error.'
+
+
+def has_verbose_errors(user):
+    """
+    True if ``user`` is allowed to see raw exception detail in API responses.
+
+    Superusers always qualify, and so do members of the
+    ``Verbose API Errors`` group (created by an admin per deployment).
+    ``settings.DEBUG`` also enables verbose errors globally — useful for
+    development and signbank-test, never for production.
+    """
+    if getattr(settings, 'DEBUG', False):
+        return True
+    if user is None or not getattr(user, 'is_authenticated', False):
+        return False
+    if getattr(user, 'is_superuser', False):
+        return True
+    return user.groups.filter(name=VERBOSE_ERRORS_GROUP).exists()
+
+
+def safe_error_message(exc, user, *, generic=GENERIC_ERROR_MESSAGE):
+    """
+    Return either the formatted exception or a generic message, depending
+    on whether ``user`` is allowed to see verbose errors.
+    """
+    if has_verbose_errors(user):
+        return f"{type(exc).__name__}: {exc}"
+    return generic

--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -24,6 +24,10 @@ from signbank.dictionary.models import (Dataset, Gloss, AnnotatedSentence)
 from signbank.tools import get_two_letter_dir, api_fields, add_gloss_update_to_revision_history
 from signbank.api_token import put_api_user_in_request
 from signbank.abstract_machine import get_interface_language_api, retrieve_language_code_from_header
+from signbank.api_receipts import (
+    sha256_of_uploaded_file, current_gloss_video_summary, current_gloss_image_summary,
+    file_summary, evaluate_idempotency_headers, upload_receipt, now_iso,
+)
 from signbank.zip_interface import (check_subfolders_for_unzipping_ids, get_filenames, check_subfolders_for_unzipping,
                                     import_video_file, remove_video_file_from_import_videos, unzip_video_files_ids,
                                     unzip_video_files)
@@ -680,6 +684,20 @@ def api_add_video(request, gloss_id):
 
     dataset = gloss.lemma.dataset
     nr_of_videos = 0
+    # Track receipt info for the center upload (the common single-file case).
+    center_label_used = None
+    center_incoming = None         # (sha256, size)
+    center_previous = None         # summary of previously stored video, or None
+    center_stored = None           # summary of new on-disk file after save
+
+    # If the client sent If-None-Match / If-Match against the *current* center
+    # video, evaluate before consuming the upload stream.
+    has_center = any(label in request.FILES for label in CENTER_VIDEO_LABELS)
+    if has_center:
+        center_previous = current_gloss_video_summary(gloss)
+        cond_response = evaluate_idempotency_headers(request, center_previous)
+        if cond_response is not None:
+            return cond_response
 
     for label in CENTER_VIDEO_LABELS:
 
@@ -687,8 +705,16 @@ def api_add_video(request, gloss_id):
             continue
 
         vfile = request.FILES[label]
+        center_label_used = label
+        # Compute sha256 + size of the incoming file before save() consumes the stream.
+        sha, size = sha256_of_uploaded_file(vfile)
+        center_incoming = (sha, size)
         gloss_video = gloss.add_video(request.user, vfile, False)
         add_gloss_update_to_revision_history(request.user, gloss, 'gloss_video', '', str(gloss_video))
+        try:
+            center_stored = file_summary(gloss_video.videofile.path)
+        except (AttributeError, ValueError):
+            center_stored = None
         nr_of_videos += 1
 
     for label in LEFT_VIDEO_LABELS:
@@ -711,7 +737,25 @@ def api_add_video(request, gloss_id):
         add_gloss_update_to_revision_history(request.user, gloss, 'gloss_perspectivevideo_right', '', str(right_perspective_video))
         nr_of_videos += 1
 
-    return JsonResponse({'message': gettext("Uploaded {nr_of_videos} videos to dataset {dataset}.").format(nr_of_videos=nr_of_videos, dataset=dataset)}, status=200)
+    msg = gettext("Uploaded {nr_of_videos} videos to dataset {dataset}.").format(nr_of_videos=nr_of_videos, dataset=dataset)
+    if center_incoming is not None:
+        receipt = upload_receipt(
+            ok=True,
+            gloss=gloss,
+            kind='video',
+            uploaded_at=now_iso(),
+            uploaded_by=getattr(request.user, 'username', None) or '',
+            incoming_sha256=center_incoming[0],
+            incoming_size=center_incoming[1],
+            stored_summary=center_stored,
+            previous_summary=center_previous,
+            message=msg,
+        )
+        receipt['nr_of_videos'] = nr_of_videos
+        receipt['label'] = center_label_used
+        return JsonResponse(receipt, status=200)
+    # No center upload (only side-cameras) — keep the legacy shape.
+    return JsonResponse({'message': msg, 'nr_of_videos': nr_of_videos}, status=200)
 
 
 @csrf_exempt
@@ -740,6 +784,15 @@ def api_add_image(request, gloss_id):
     goal_path = os.path.join(WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY, gloss.lemma.dataset.acronym, get_two_letter_dir(gloss.idgloss))
     goal_location = os.path.join(goal_path, quote(image_file.name, safe=''))
 
+    # Idempotency: refuse on If-None-Match: * if anything is already stored for this gloss.
+    previous_image = current_gloss_image_summary(gloss)
+    cond_response = evaluate_idempotency_headers(request, previous_image)
+    if cond_response is not None:
+        return cond_response
+
+    # Hash the incoming bytes before save() consumes the stream.
+    incoming_sha, incoming_size = sha256_of_uploaded_file(image_file)
+
     if not os.path.exists(goal_path):
         try:
             os.makedirs(goal_path)
@@ -757,4 +810,16 @@ def api_add_image(request, gloss_id):
 
     destination.close()
 
-    return JsonResponse({'message': gettext('Image upload successful.')}, status=200)
+    receipt = upload_receipt(
+        ok=True,
+        gloss=gloss,
+        kind='image',
+        uploaded_at=now_iso(),
+        uploaded_by=getattr(request.user, 'username', None) or '',
+        incoming_sha256=incoming_sha,
+        incoming_size=incoming_size,
+        stored_summary=file_summary(goal_location),
+        previous_summary=previous_image,
+        message=gettext('Image upload successful.'),
+    )
+    return JsonResponse(receipt, status=200)

--- a/signbank/api_middleware.py
+++ b/signbank/api_middleware.py
@@ -1,0 +1,70 @@
+"""
+Turns uncaught exceptions on API endpoints into a JSON 500 instead of the
+default HTML error page. Browser hits the same URL still get HTML; JSON /
+API clients get something they can parse.
+"""
+
+import logging
+
+from django.http import JsonResponse
+
+from signbank.api_errors import has_verbose_errors, GENERIC_ERROR_MESSAGE
+
+
+log = logging.getLogger(__name__)
+
+
+API_VIEW_MODULES = (
+    'signbank.api_',
+    'signbank.gloss_update',
+    'signbank.zip_interface',
+)
+
+
+def _is_api_view(request):
+    """
+    Decide whether ``request`` is for an API endpoint without hard-coding
+    URL prefixes. Order of preference:
+
+      1. The view that resolved the URL lives in one of the API modules
+         listed above (introspected via ``request.resolver_match.func``).
+      2. The client explicitly asked for JSON (and not HTML) via the
+         ``Accept`` header — covers cases where URL resolution has not run
+         yet or the view lives outside ``signbank.api_*``.
+    """
+    rm = getattr(request, 'resolver_match', None)
+    view = getattr(rm, 'func', None) if rm else None
+    module = getattr(view, '__module__', '') or ''
+    if any(module.startswith(prefix) for prefix in API_VIEW_MODULES):
+        return True
+    accept = (request.META.get('HTTP_ACCEPT') or '').lower()
+    return 'json' in accept and 'html' not in accept
+
+
+class JsonErrorMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        if not _is_api_view(request):
+            return None
+        log.exception(
+            "api 500 on %s %s: %s", request.method, request.path, exception
+        )
+        verbose = has_verbose_errors(getattr(request, 'user', None))
+        body = {
+            'ok': False,
+            'status_code': 500,
+            'errors': [{
+                'field': None,
+                'code': 'internal_error',
+                'message': f"{type(exception).__name__}: {exception}" if verbose else GENERIC_ERROR_MESSAGE,
+            }],
+        }
+        if verbose:
+            import traceback
+            body['traceback'] = traceback.format_exc().splitlines()[-30:]
+        return JsonResponse(body, status=500)

--- a/signbank/api_receipts.py
+++ b/signbank/api_receipts.py
@@ -1,0 +1,222 @@
+"""
+Helpers for emitting upload receipts on the api_add_video / api_add_image
+endpoints:
+
+* every upload returns metadata the client can use to prove later *which*
+  file landed (sha256, size, uploaded_at, uploaded_by, stored path);
+* if the upload replaced an existing file, the prior file's metadata is
+  reported under ``replaced``;
+* clients can opt into refusal-on-overwrite by sending ``If-None-Match: *``
+  or refusal-on-mismatch via ``If-Match: "<sha256>"``.
+
+See ``docs/signbank-api-recommendations.md`` (#1 and #2) for the design
+rationale.
+"""
+
+import hashlib
+import os
+from datetime import datetime, timezone
+
+from django.http import JsonResponse
+
+from signbank.tools import get_two_letter_dir
+from signbank.settings.server_specific import WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY
+
+
+ISO_8601_UTC = '%Y-%m-%dT%H:%M:%SZ'
+
+
+def _iso_utc(dt):
+    """Format a datetime as RFC 3339 / ISO 8601, UTC, second precision."""
+    return dt.strftime(ISO_8601_UTC)
+
+
+def now_iso():
+    return _iso_utc(datetime.now(tz=timezone.utc))
+
+
+def sha256_of_uploaded_file(uploaded_file):
+    """
+    Compute the SHA-256 of a Django UploadedFile *without* losing the read
+    cursor. Returns the hex digest and the file size in bytes.
+
+    Uses chunked iteration so we don't load large videos into memory.
+    """
+    h = hashlib.sha256()
+    size = 0
+    for chunk in uploaded_file.chunks():
+        size += len(chunk)
+        h.update(chunk)
+    try:
+        uploaded_file.seek(0)
+    except (AttributeError, OSError):
+        pass
+    return h.hexdigest(), size
+
+
+def sha256_of_path(path):
+    """Compute SHA-256 + size for an existing file on disk, or (None, None) if absent."""
+    if not path or not os.path.isfile(path):
+        return None, None
+    h = hashlib.sha256()
+    size = 0
+    with open(path, 'rb') as file:
+        for chunk in iter(lambda: file.read(1024 * 64), b''):
+            size += len(chunk)
+            h.update(chunk)
+    return h.hexdigest(), size
+
+
+def file_summary(path, *, include_path=True):
+    """
+    Build a plain dict describing the file at `path` — sha256, size_bytes,
+    uploaded_at (file mtime), filename, optionally the stored path.
+
+    Returns ``None`` if the file doesn't exist.
+    """
+    if not path or not os.path.isfile(path):
+        return None
+    sha, size = sha256_of_path(path)
+    mtime = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+    info = {
+        'filename':    os.path.basename(path),
+        'sha256':      sha,
+        'size_bytes':  size,
+        'uploaded_at': _iso_utc(mtime),
+    }
+    if include_path:
+        info['stored_path'] = path
+    return info
+
+
+def current_gloss_video_summary(gloss):
+    """
+    Return a dict describing the gloss's current center video (version 0),
+    or ``None`` if no video exists.
+    """
+    try:
+        gloss_video = gloss.glossvideo_set.filter(version=0).first()
+    except (AttributeError, ValueError):
+        gloss_video = None
+    if not gloss_video or not gloss_video.videofile:
+        return None
+    try:
+        path = gloss_video.videofile.path
+    except (AttributeError, ValueError):
+        return None
+    return file_summary(path)
+
+
+def current_gloss_image_summary(gloss):
+    """Approximate "current image" lookup based on the convention used by api_add_image."""
+    try:
+        base_dir = os.path.join(WRITABLE_FOLDER, GLOSS_IMAGE_DIRECTORY,
+                                gloss.lemma.dataset.acronym, get_two_letter_dir(gloss.idgloss))
+    except (AttributeError, ValueError):
+        return None
+    if not os.path.isdir(base_dir):
+        return None
+    prefix = f"{gloss.idgloss}-{gloss.pk}."
+    candidates = [name for name in os.listdir(base_dir) if name.startswith(prefix)]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda name: os.path.getmtime(os.path.join(base_dir, name)), reverse=True)
+    return file_summary(os.path.join(base_dir, candidates[0]))
+
+
+def precondition_failed(message, current=None):
+    """Build the JSON body for a 412 Precondition Failed response."""
+    body = {
+        'ok': False,
+        'status_code': 412,
+        'errors': [{'field': None, 'code': 'precondition_failed', 'message': message}],
+    }
+    if current is not None:
+        body['current'] = current
+    return body
+
+
+def _parse_if_match(header_value):
+    """
+    Parse an ``If-Match`` header per RFC 9110: a comma-separated list of
+    quoted ETag values, or the literal ``*``. Returns a list of unquoted
+    ETag strings (``['*']`` for the wildcard, ``[]`` if the header is empty).
+    """
+    value = (header_value or '').strip()
+    if not value:
+        return []
+    if value == '*':
+        return ['*']
+    tags = []
+    for raw in value.split(','):
+        token = raw.strip()
+        if token.startswith('W/'):
+            token = token[2:].strip()
+        if len(token) >= 2 and token.startswith('"') and token.endswith('"'):
+            token = token[1:-1]
+        if token:
+            tags.append(token)
+    return tags
+
+
+def evaluate_idempotency_headers(request, current_summary):
+    """
+    Inspect ``If-None-Match`` / ``If-Match`` headers and, if a precondition
+    fails, return the JsonResponse the view should return immediately.
+    Otherwise returns ``None``.
+    """
+    if not current_summary:
+        return None
+
+    if request.headers.get('If-None-Match', '').strip() == '*':
+        return JsonResponse(
+            precondition_failed(
+                "A file already exists for this gloss; refused because of If-None-Match: *.",
+                current=current_summary,
+            ),
+            status=412,
+        )
+
+    if_match_tags = _parse_if_match(request.headers.get('If-Match', ''))
+    if if_match_tags:
+        current_sha = current_summary.get('sha256')
+        if '*' not in if_match_tags and current_sha not in if_match_tags:
+            return JsonResponse(
+                precondition_failed(
+                    f"If-Match precondition failed; current sha256 is "
+                    f"{current_sha!r} (expected one of {if_match_tags!r}).",
+                    current=current_summary,
+                ),
+                status=412,
+            )
+
+    return None
+
+
+def upload_receipt(*, ok, gloss, kind, uploaded_at, uploaded_by,
+                   incoming_sha256, incoming_size, stored_summary,
+                   previous_summary, message):
+    """
+    Build the unified receipt dict. ``kind`` is "video" or "image".
+
+    ``incoming_*`` keys describe what the client sent; ``stored_*`` keys
+    describe what landed on disk after save (post-conversion size / hash
+    can differ from the upload).
+    """
+    receipt = {
+        'ok': ok,
+        'message':     message,
+        'gloss_id':    gloss.pk,
+        'kind':        kind,
+        'uploaded_at': uploaded_at,
+        'uploaded_by': uploaded_by,
+        'sha256':      incoming_sha256,
+        'size_bytes':  incoming_size,
+    }
+    if stored_summary:
+        receipt['stored_filename']   = stored_summary.get('filename')
+        receipt['stored_path']       = stored_summary.get('stored_path')
+        receipt['stored_size_bytes'] = stored_summary.get('size_bytes')
+        receipt['stored_sha256']     = stored_summary.get('sha256')
+    receipt['replaced'] = previous_summary
+    return receipt

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -28,6 +28,7 @@ from signbank.video.views import get_glosses_from_eaf
 from signbank.tools import get_default_annotationidglosstranslation, add_gloss_update_to_revision_history
 from signbank.csv_interface import normalize_field_choice, normalize_boolean
 from signbank.api_token import put_api_user_in_request
+from signbank.api_errors import safe_error_message
 from signbank.abstract_machine import retrieve_language_code_from_header
 
 
@@ -740,10 +741,8 @@ def api_update_gloss(request, datasetid, glossid, language_code='en'):
 
     try:
         gloss_update_do_changes(request.user, gloss, fields_to_update, interface_language_code)
-    except (TransactionManagementError, ValueError, IntegrityError):
-        errors = dict()
-        errors[gettext('Exception')] = gettext("Transaction management error.")
-        results['errors'] = errors
+    except (TransactionManagementError, ValueError, IntegrityError) as exc:
+        results['errors'] = {gettext('Exception'): safe_error_message(exc, request.user)}
         results['updatestatus'] = "Failed"
         return JsonResponse(results, status=400)
 

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -61,7 +61,8 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'signbank.pages.middleware.PageFallbackMiddleware',
     'reversion.middleware.RevisionMiddleware',
-    'django.middleware.common.CommonMiddleware'
+    'django.middleware.common.CommonMiddleware',
+    'signbank.api_middleware.JsonErrorMiddleware',
 )
 
 CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Implements §1, §2, §5 from `docs/signbank-api-recommendations.md` plus the role-based error-detail gating discussed in @Woseseltops's reply on #1743.

### New
- **`signbank/api_receipts.py`** — `sha256_of_uploaded_file`, `file_summary`, RFC-9110 `If-Match` parser (`_parse_if_match`), `evaluate_idempotency_headers`, `upload_receipt`. Handles `"a", "b"`-style comma-separated quoted ETag lists and `W/`-prefixed weak validators per the review.
- **`signbank/api_middleware.py`** — `JsonErrorMiddleware`: catches uncaught exceptions on API endpoints and emits a JSON 500. Targets API endpoints by introspecting the resolved view's `__module__` (`signbank.api_*`, `gloss_update`, `zip_interface`) with `Accept: application/json` as a fallback — no more hard-coded URL prefixes.
- **`signbank/api_errors.py`** — `has_verbose_errors(user)` + `safe_error_message(exc, user)`. Raw Python exception text is only included in API responses for `settings.DEBUG`, superusers, or members of the `Verbose API Errors` group; everyone else gets `"Internal server error."`

### Modified
- **`signbank/api_interface.py`** — `api_add_video` / `api_add_image` compute the incoming sha256 before save, evaluate `If-Match` / `If-None-Match` against the current stored file, and return an `UploadReceipt` (sha256 + size of incoming and stored, `replaced` block for prior file).
- **`signbank/gloss_update.py`** — exception text in the `api_update_gloss` 400 response now goes through `safe_error_message()` instead of being surfaced verbatim.
- **`signbank/settings/base.py`** — `JsonErrorMiddleware` registered.
- **`docs/signbank-api.json`** — `UploadReceipt`, `FileSummary`, `ApiError` schemas; `If-Match` / `If-None-Match` parameters; 412 / 500 response shapes on `/dictionary/api_update_gloss/{glossid}/video` and `.../image`.

### Deployment note
The role-based gate is opt-in: enable verbose errors for an API user by adding them to a `Verbose API Errors` group (`Group.objects.get_or_create(name='Verbose API Errors')`). Until that group exists, only `DEBUG=True` and superusers get raw exception text.

### Replaces
#1743 — this is the substantive piece of the 5-way split requested in the review. The other four are #1746, #1747, #1748, #1749.

Cc @vanlummelhuizen @Woseseltops @susanodd — the top-level reply on #1743 has the per-thread responses; happy to also paste them inline here if preferred.